### PR TITLE
Updated CloudCannon pricing info

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Prose](https://github.com/prose/prose) - A beautifully simple content authoring environment for static websites.
 - [Content Editor](https://github.com/mushishi78/content-editor)- A web interface for editing documents on GitHub.
-- [cloudcannon](http://cloudcannon.com/) - Free for 1 user, $9/month for 5 users. Hosting for static websites where developers can set it up so that non-developers can edit the site.
+- [CloudCannon](http://cloudcannon.com/) - Hosting for static websites where developers can set it up so that non-developers can edit the site. Basic plan starts at $25 per user.
 - [potion](https://github.com/captn3m0/potion) - A github-pages compatible editor for Jekyll blogs.
 - [jekyll-post-via-web](https://github.com/vrypan/jekyll-post-via-web) - Html page that allows you to post new articles to your Github hosted site.
 - [Github's Online Interface](https://help.github.com/articles/github-flow-in-the-browser/) - You can just edit your site in Github's online interface if your site's code is hosted on Github.


### PR DESCRIPTION
Pricing was listed as being free for 1 user and $9 per additional user. This was probably outdated info, as [the website](http://cloudcannon.com/pricing/) now has the cheapest plan at $25 per user.

Then again, maybe it would be better to not list the pricing here at all? Since this seems to be the only item on the list to have pricing info.

Also, I capitalised the name like on the website (was all lowercase).