### PR TITLE
Add `jtasks` a CLI automation tool to simplify Jekyll routines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Gynn](https://github.com/dmathieu/glynn) - Generate your Jekyll blog files and sends them through FTP.
 - [(JBH) Jekyll Blog Helper](https://github.com/AlanBarber/jbh) - A shell script to help manage a Jekyll blog site.
 - [mrhyde](https://github.com/mrhydescripts/mrhyde) - Static site quick starter script wizard.
+- [jtasks](https://github.com/pavdmyt/jtasks) - A set of configurable tasks for Jekyll projects.
 
 ## Themes
 


### PR DESCRIPTION
[Jtasks](https://github.com/pavdmyt/jtasks) is a tool I created to simplify and automate a lot of dev routines in Jekyll projects. Currently it supports following tasks:

```
  build     Build the site.
  clean     Clean the site.
  doctor    Search site and print specific deprecation warnings.
  list      List all posts.
  notify    Notify various services about sitemap update.
  post      Create a new post.
  preview   Launches default browser for previewing generated site.
  serve     Serve the site locally.
```

With *Settings* part of the script, it's easily configurable for per-project basis. Check this [blog post](http://pavdmyt.com/simplifying-extending-jekyll-cli-with-jtasks/) for more details.