### PR TITLE
Added GitLab static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Forge](https://getforge.com/) - Static web hosting made simple, sync with github and publish to CDN and optimize your javascript.
 - [CloudCannon](http://cloudcannon.com/) - Hosting for static websites where developers can set it up so that non-developers can edit the site.
 - [BowTie](https://bowtie.io/) - Static website hosting with online editor (using prose).
+- [GitLab Pages](https://pages.gitlab.io/) - Free static hosting from GitLab.
 
 ### Hosting Tools
 


### PR DESCRIPTION
Added the recently released GitLab Pages to the list of static hosting services.