### PR TITLE
Clean up spacing after links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Appernetic] (https://appernetic.io) - A Static Site Generator as a Service.
 - [Prose](https://github.com/prose/prose) - A beautifully simple content authoring environment for static websites.
-- [Content Editor](https://github.com/mushishi78/content-editor)- A web interface for editing documents on GitHub.
+- [Content Editor](https://github.com/mushishi78/content-editor) - A web interface for editing documents on GitHub.
 - [potion](https://github.com/captn3m0/potion) - A github-pages compatible editor for Jekyll blogs.
 - [jekyll-post-via-web](https://github.com/vrypan/jekyll-post-via-web) - Html page that allows you to post new articles to your Github hosted site.
 - [Github's Online Interface](https://help.github.com/articles/github-flow-in-the-browser/) - You can just edit your site in Github's online interface if your site's code is hosted on Github.
-- [Siteleaf](http://www.siteleaf.com/)- Online editor content manager that allows you to publish anywhere, including Github Pages, and it has Jekyll support.
+- [Siteleaf](http://www.siteleaf.com/) - Online editor content manager that allows you to publish anywhere, including Github Pages, and it has Jekyll support.
 - [Surreal CMS](http://www.surrealcms.com/) - Hosted CMS for static sites over FTP or Amazon S3.
 
 ### Android Editors
@@ -84,12 +84,12 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ### Jekyll Themes
 
 - [JekyllThemes.org](http://jekyllthemes.org/) - Website showcasing Jekyll themes.
-- [Jekyll Wiki Themes](https://github.com/jekyll/jekyll/wiki/Themes)- List of themes on the Jekyll wiki.
+- [Jekyll Wiki Themes](https://github.com/jekyll/jekyll/wiki/Themes) - List of themes on the Jekyll wiki.
 - [JekyllThemes.io](http://jekyllthemes.io/) - Premium and Free Jekyll Themes.
 
 ## Static Site Generators
 
-- [StaticGen](http://www.staticgen.com/)- Website showing static site generators and a lot of info about them.
+- [StaticGen](http://www.staticgen.com/) - Website showing static site generators and a lot of info about them.
 
 ## Embeddable Content
 
@@ -97,7 +97,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [SoundCloud](https://soundcloud.com/) - Audio hosting with an embeddable player. Up to 3 hours of content is free.
 - [Mixcloud](https://www.mixcloud.com/) - Audio hosting with unlimited uploads and an embeddable player.
-- [Spotify](https://www.spotify.com/)- You can embed any song, album, or playlist with a [Spotify Play Button](https://developer.spotify.com/technologies/widgets/spotify-play-button/).
+- [Spotify](https://www.spotify.com/) - You can embed any song, album, or playlist with a [Spotify Play Button](https://developer.spotify.com/technologies/widgets/spotify-play-button/).
 
 ### Books
 
@@ -162,13 +162,13 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Formspree](http://formspree.io/) - Receive emails from a form on your static website.
 - [elFormo](https://www.elformo.com/) - Simple form processing and response retrieval via email.
 - [Flipmail](http://flipmail.co/) - Simple form processing and response retrieval via email.
-- [MailThis](http://mailthis.to/)- Simple form submissions via email with optional attachments.
+- [MailThis](http://mailthis.to/) - Simple form submissions via email with optional attachments.
 - [Simple Form](https://getsimpleform.com/) - Simple forms with optional file attachments, email notifications, and online submission viewing.
 - [Brisk Forms](https://github.com/stevensona/briskforms) - Free form submission service emails you responses while keeping your email address private and is open source.
 
 #### Normal Forms
 
-- [Google Forms](https://www.google.com/forms/about/)- Saves results into Google Sheets and can email you when there is a submission.
+- [Google Forms](https://www.google.com/forms/about/) - Saves results into Google Sheets and can email you when there is a submission.
 - [FormKeep](https://formkeep.com/) - Paid - View form submissions in a beautiful web interface. It has spam filtering and it integrates with webhooks such as Gmail, Trello, and Basecamp.
 - [123 Contact Form](http://www.123contactform.com/) - Connects to other online services such at MailChimp, Salesforce, and Google Drive. It also integreates with payment Processers and includes security and analytics.
 - [FormAssembly](http://www.formassembly.com/)


### PR DESCRIPTION
Consistent spacing between links and hyphens, to follow guidelines in contributing.md.